### PR TITLE
Addding latest WAVE4 firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 | - | - |
 | PSA_ovip-int-firmware-version_42-01-72-32_NAC-r0_NAC_EUR_WAVE4.tar | https://majestic-web.mpsa.com/nas/eu/mjb00/NAC_EU/ovip-int-firmware-version/PSA_ovip-int-firmware-version_42-01-72-32_NAC-r0_NAC_EUR_WAVE4.tar |
 | PSA_ovip-int-firmware-version_42-03-31-32_NAC-r0_NAC_EUR_WAVE4.tar | https://majestic-web.mpsa.com/nas/eu/mjb00/NAC_EU/ovip-int-firmware-version/PSA_ovip-int-firmware-version_42-03-31-32_NAC-r0_NAC_EUR_WAVE4.tar |
+| PSA_ovip-int-firmware-version_42-03-33-42_NAC-r0_NAC_EUR_WAVE4.tar | https://majestic-web.mpsa.com/nas/eu/mjb00/NAC_EU/ovip-int-firmware-version/PSA_ovip-int-firmware-version_42-03-33-42_NAC-r0_NAC_EUR_WAVE4.tar |
 
 ### WAVE2_CN
 


### PR DESCRIPTION
Adding the latest WAVE4 firmware to the list: 42-03-33-42_NAC-r0.
@ludwig-v it would be great if you can assist with the location of the 'key' to decrypt the files held within - where is this found?